### PR TITLE
Readme - odin EMAC in mbed_app.json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,7 @@ and performs simple HTTP operation.
 
 ### Supported hardware ###
 
-* UBLOX Odin board (UBLOX_EVK_ODIN_W2) *NOTE*: WiFi is disabled by default for this board, to enable it you'll need to
-  modify mbed-os/targets/targets.json file and add ```"EMAC"``` flag in ```device_has``` section for
-  ```UBLOX_EVK_ODIN_W2``` target.
+* UBLOX Odin board (UBLOX_EVK_ODIN_W2)
 * ESP2866 module (Board it's connected to shouldn't have other network interface eg. Ethernet)
 
 ESP2866 is a fallback option and will be used if the build is for unsupported platform.

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -1,0 +1,7 @@
+{
+    "target_overrides": {
+        "UBLOX_EVK_ODIN_W2": {
+            "target.device_has": ["EMAC"]
+        }
+    }
+}


### PR DESCRIPTION
Add target.device_has EMAC for wifi application. This is a workaround for the
current limitation that EMAC is disabled by default.

Fixes #3 issue.

@MarceloSalazar @andreaslarssonublox @bulislaw 